### PR TITLE
MatrixZoomData not used in this call.  Added null check so won't get …

### DIFF
--- a/src/juicebox/mapcolorui/Feature2DHandler.java
+++ b/src/juicebox/mapcolorui/Feature2DHandler.java
@@ -41,6 +41,7 @@ import java.util.*;
 import java.util.List;
 
 /**
+ * Handles 2D features such as domains and peaks
  * Created by muhammadsaadshamim on 8/6/15.
  */
 public class Feature2DHandler {
@@ -80,10 +81,6 @@ public class Feature2DHandler {
         int w = (int) Math.max(1, scaleFactor * (binEnd1 - binStart1)) + offsetDoubled;
         int h = (int) Math.max(1, scaleFactor * (binEnd2 - binStart2)) + offsetDoubled;
 
-        if (feature.getTest()) {
-//            System.out.println("  Pixel data (1): " + x + ", " + (x + w));
-//            System.out.println("  Pixel data (2): " + y + ", " + (y + h));
-        }
 
         return new Rectangle(x, y, w, h);
     }
@@ -282,7 +279,7 @@ public class Feature2DHandler {
         return featurePairs;
     }
 
-    public List<Feature2D> findContainedFeatures(MatrixZoomData zd, int chrIdx1, int chrIdx2, net.sf.jsi.Rectangle currentWindow) {
+    public List<Feature2D> findContainedFeatures(int chrIdx1, int chrIdx2, net.sf.jsi.Rectangle currentWindow) {
         final List<Feature2D> foundFeatures = new ArrayList<Feature2D>();
         final String key = Feature2DList.getKey(chrIdx1, chrIdx2);
 
@@ -301,7 +298,8 @@ public class Feature2DHandler {
             );
 
         } else {
-            foundFeatures.addAll(allFeaturesAcrossGenome.get(key));
+            List<Feature2D> features = allFeaturesAcrossGenome.get(key);
+            if (features != null) foundFeatures.addAll(features);
         }
 
         return foundFeatures;

--- a/src/juicebox/tools/clt/juicer/HiCCUPS.java
+++ b/src/juicebox/tools/clt/juicer/HiCCUPS.java
@@ -453,7 +453,7 @@ public class HiCCUPS extends JuicerCLT {
                                                 // System.out.println(chromosome.getIndex() + "\t" + rowBound1GenomeCoords + "\t" + rowBound2GenomeCoords + "\t" + columnBound1GenomeCoords + "\t" + columnBound2GenomeCoords);
                                                 net.sf.jsi.Rectangle currentWindow = new net.sf.jsi.Rectangle(rowBound1GenomeCoords,
                                                         columnBound1GenomeCoords, rowBound2GenomeCoords, columnBound2GenomeCoords);
-                                                List<Feature2D> inputListFoundFeatures = inputListFeature2DHandler.findContainedFeatures(zd, chromosome.getIndex(), chromosome.getIndex(),
+                                                List<Feature2D> inputListFoundFeatures = inputListFeature2DHandler.findContainedFeatures(chromosome.getIndex(), chromosome.getIndex(),
                                                         currentWindow);
                                                 Feature2DList peaksRequestedList = gpuOutputs.extractPeaksListGiven(chromosome.getIndex(), chromosome.getName(),
                                                         w1, w2, rowBounds[4], columnBounds[4], conf.getResolution(), inputListFoundFeatures);
@@ -544,7 +544,8 @@ public class HiCCUPS extends JuicerCLT {
     }
 
     /**
-     * @param juicerParser
+     * Determine valid configurations from command line, set defaults
+     * @param juicerParser  Command line parser handle
      */
     private void determineValidConfigurations(CommandLineParserForJuicer juicerParser) {
 
@@ -559,6 +560,7 @@ public class HiCCUPS extends JuicerCLT {
         try {
             List<String> t = juicerParser.getThresholdOptions();
             if (t.size() > 1) {
+                // TODO: bad programming style to create unnecessary exceptions, just look for null instead.
                 double[] thresholds = HiCCUPSUtils.extractDoubleValues(t, 4, -1f);
                 fdrsum = thresholds[0];
                 oeThreshold1 = thresholds[1];

--- a/src/juicebox/tools/clt/juicer/HiCCUPSDiff.java
+++ b/src/juicebox/tools/clt/juicer/HiCCUPSDiff.java
@@ -117,6 +117,9 @@ public class HiCCUPSDiff extends JuicerCLT {
                 System.exit(1);
             }
         }
+        // TODO: right now this code is repeated (cut and pasted into HiCCUPSConfiguration; should instead either
+        // use HiCCUPSConfiguration directly or use the fact that we have the juicerParser already.
+        // the tricky part is that we might change the resolutions based on whether or not that resolution is present.
         List<String> fdrOpts = juicerParser.getFDROptions();
         List<String> pOpts = juicerParser.getPeakOptions();
         List<String> iOpts = juicerParser.getWindowOptions();

--- a/src/juicebox/tools/utils/juicer/hiccups/HiCCUPSConfiguration.java
+++ b/src/juicebox/tools/utils/juicer/hiccups/HiCCUPSConfiguration.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * Helper class for creating default HiCCUPS configurations
  * Created by muhammadsaadshamim on 10/8/15.
  */
 public class HiCCUPSConfiguration {
@@ -87,13 +88,46 @@ public class HiCCUPSConfiguration {
      */
 
     public static HiCCUPSConfiguration[] extractConfigurationsFromCommandLine(CommandLineParserForJuicer juicerParser) {
-        List<String> resString = juicerParser.getMultipleResolutionOptions();
-        if (resString == null) return null;
-        int[] resolutions = ArrayTools.extractIntegers(resString);
-        double[] fdr = HiCCUPSUtils.extractFDRValues(juicerParser.getFDROptions(), resolutions.length, 0.1f); // becomes default 10
-        int[] peaks = HiCCUPSUtils.extractIntegerValues(juicerParser.getPeakOptions(), resolutions.length, 2);
-        int[] windows = HiCCUPSUtils.extractIntegerValues(juicerParser.getWindowOptions(), resolutions.length, 5);
-        int[] radii = HiCCUPSUtils.extractIntegerValues(juicerParser.getClusterRadiusOptions(), resolutions.length, 20000);
+        List<String> resOpts = juicerParser.getMultipleResolutionOptions();
+        if (resOpts == null) return null;
+
+        List<String> fdrOpts = juicerParser.getFDROptions();
+        List<String> pOpts = juicerParser.getPeakOptions();
+        List<String> iOpts = juicerParser.getWindowOptions();
+        List<String> dOpts = juicerParser.getClusterRadiusOptions();
+
+        if (fdrOpts == null) {
+            fdrOpts = new ArrayList<String>();
+            if (resOpts.contains("5000")) fdrOpts.add("0.1");
+            if (resOpts.contains("10000")) fdrOpts.add("0.1");
+            if (resOpts.contains("25000")) fdrOpts.add("0.1");
+        }
+        if (pOpts == null) {
+            pOpts = new ArrayList<String>();
+            if (resOpts.contains("5000")) pOpts.add("4");
+            if (resOpts.contains("10000")) pOpts.add("2");
+            if (resOpts.contains("25000")) pOpts.add("1");
+        }
+        if (iOpts == null) {
+            iOpts = new ArrayList<String>();
+            if (resOpts.contains("5000")) iOpts.add("7");
+            if (resOpts.contains("10000")) iOpts.add("5");
+            if (resOpts.contains("25000")) iOpts.add("3");
+        }
+        if (dOpts == null) {
+            dOpts = new ArrayList<String>();
+            if (resOpts.contains("5000")) dOpts.add("20000");
+            if (resOpts.contains("10000")) dOpts.add("20000");
+            if (resOpts.contains("25000")) dOpts.add("50000");
+        }
+
+        int[] resolutions = ArrayTools.extractIntegers(resOpts);
+        double[] fdr = HiCCUPSUtils.extractFDRValues(fdrOpts, resolutions.length, 0.1f); // becomes default 10
+        // peaks, windows, and radii all have different default values depending on resolution
+        // if the user specifies values per resolution, they are stored here, otherwise null
+        int[] peaks = HiCCUPSUtils.extractIntegerValues(pOpts, resolutions.length);
+        int[] windows = HiCCUPSUtils.extractIntegerValues(iOpts, resolutions.length);
+        int[] radii = HiCCUPSUtils.extractIntegerValues(dOpts, resolutions.length);
 
         HiCCUPSConfiguration[] configurations = new HiCCUPSConfiguration[resolutions.length];
         for (int i = 0; i < resolutions.length; i++) {

--- a/src/juicebox/tools/utils/juicer/hiccups/HiCCUPSUtils.java
+++ b/src/juicebox/tools/utils/juicer/hiccups/HiCCUPSUtils.java
@@ -44,6 +44,7 @@ import java.util.*;
 import java.util.List;
 
 /**
+ * Utility class for HiCCUPS
  * Created by muhammadsaadshamim on 6/2/15.
  */
 public class HiCCUPSUtils {
@@ -239,7 +240,7 @@ public class HiCCUPSUtils {
         // HashSet intermediate for removing duplicates; LinkedList used so that we can pop out highest obs values
         LinkedList<Feature2D> featureLL = new LinkedList<Feature2D>(new HashSet<Feature2D>(feature2DList));
         List<Feature2D> coalesced = new ArrayList<Feature2D>();
-        double r = 0;
+
         while (!featureLL.isEmpty()) {
 
             // See Feature2D
@@ -279,7 +280,7 @@ public class HiCCUPSUtils {
                         distances.add(dist);
                     }
                     //System.out.println("Radii "+distances);
-                    r = Math.round(Collections.max(distances));
+                    double r = Math.round(Collections.max(distances));
 
                     pixelClusterRadius = originalClusterRadius + r;
                 }
@@ -477,10 +478,10 @@ public class HiCCUPSUtils {
         return mergedList;
     }
 
-    public static int[] extractIntegerValues(List<String> valList, int n, int defaultVal) {
+    public static int[] extractIntegerValues(List<String> valList, int n) {
 
         if (valList == null) {
-            return ArrayTools.preInitializeIntArray(defaultVal, n);
+            return null;
         } else {
             int[] result = ArrayTools.extractIntegers(valList);
             if (result.length == n) {


### PR DESCRIPTION
…NullPointerException if allFeaturesAcrossGenome doesn't contain that chromosome.

Added in appropriate defaults for 5Kb, 10Kb, and 25Kb.
