### PR TITLE
pearsons can now be calculated for high resolution as long as -p is set

### DIFF
--- a/src/juicebox/tools/clt/old/Pearsons.java
+++ b/src/juicebox/tools/clt/old/Pearsons.java
@@ -167,7 +167,7 @@ public class Pearsons extends JuiceboxCLT {
             printUsageAndExit();
         }
 
-        HiCGlobals.MAX_PEARSON_ZOOM = 500000;
+        //HiCGlobals.MAX_PEARSON_ZOOM = 500000;
         setDatasetAndNorm(args[2], args[1], true);
         ChromosomeHandler chromosomeHandler = dataset.getChromosomeHandler();
 
@@ -192,19 +192,21 @@ public class Pearsons extends JuiceboxCLT {
             System.err.println("Integer expected for bin size.  Found: " + binSizeSt + ".");
             System.exit(21);
         }
-
+/***
         if ((unit == HiC.Unit.BP && binSize < HiCGlobals.MAX_PEARSON_ZOOM) ||
                 (unit == HiC.Unit.FRAG && binSize < HiCGlobals.MAX_PEARSON_ZOOM / 1000)) {
             System.out.println("Pearson's and Eigenvector are not calculated for high resolution datasets");
             System.out.println("To override this limitation, send in the \"-p\" flag.");
             System.exit(0);
         }
+ ***/
 
         if (args.length == 7) {
             ofile = args[6];
         }
 
     }
+
 
     @Override
     public void run() {
@@ -335,5 +337,7 @@ public class Pearsons extends JuiceboxCLT {
         les.writeInt(BLOCK_TILE);
     }
 }
+
+
 
 

--- a/src/juicebox/tools/clt/old/Pearsons.java
+++ b/src/juicebox/tools/clt/old/Pearsons.java
@@ -192,21 +192,19 @@ public class Pearsons extends JuiceboxCLT {
             System.err.println("Integer expected for bin size.  Found: " + binSizeSt + ".");
             System.exit(21);
         }
-/***
+
         if ((unit == HiC.Unit.BP && binSize < HiCGlobals.MAX_PEARSON_ZOOM) ||
                 (unit == HiC.Unit.FRAG && binSize < HiCGlobals.MAX_PEARSON_ZOOM / 1000)) {
             System.out.println("Pearson's and Eigenvector are not calculated for high resolution datasets");
             System.out.println("To override this limitation, send in the \"-p\" flag.");
             System.exit(0);
         }
- ***/
 
         if (args.length == 7) {
             ofile = args[6];
         }
 
     }
-
 
     @Override
     public void run() {
@@ -337,7 +335,3 @@ public class Pearsons extends JuiceboxCLT {
         les.writeInt(BLOCK_TILE);
     }
 }
-
-
-
-


### PR DESCRIPTION
@sa501428 @nchernia 

Before the change, HiCGlobals.MAX_PEARSON_ZOOM which is set to (500kb) sets the limit, and when the resolution is set to be smaller than this value, it quits the job.