### PR TITLE
No all

### DIFF
--- a/src/juicebox/HiC.java
+++ b/src/juicebox/HiC.java
@@ -67,7 +67,7 @@ public class HiC {
     private double scaleFactor;
     private String xPosition;
     private String yPosition;
-    private MatrixType displayOption;
+    private MatrixType displayOption = MatrixType.OBSERVED;
     private NormalizationType obsNormalizationType, ctrlNormalizationType;
     private ChromosomeHandler chromosomeHandler;
     private Dataset dataset;
@@ -117,8 +117,15 @@ public class HiC {
         return null;
     }
 
+    public Unit getDefaultUnit() {
+        return dataset.getBpZooms().size() > 0 ? Unit.BP : Unit.FRAG;
+    }
+
     public void reset() {
         dataset = null;
+        controlDataset = null;
+        displayOption = MatrixType.OBSERVED;
+        currentZoom = null;
         resetContexts();
         chromosomeHandler = null;
         eigenvectorTrack = null;
@@ -128,6 +135,7 @@ public class HiC {
         obsNormalizationType = NormalizationHandler.NONE;
         ctrlNormalizationType = NormalizationHandler.NONE;
         zoomActionTracker.clear();
+        binSizeDictionary.clear();
         clearFeatures();
     }
 
@@ -736,9 +744,9 @@ public class HiC {
      * @param newZoom
      * @param genomeX
      * @param genomeY
-     * @param scaleFactor (pass -1 if scaleFactor should be calculated)
+     * @param scaleFactor      (pass -1 if scaleFactor should be calculated)
      * @param resolutionLocked (pass -1 if status of lock button should not be saved)
-     * @param storeZoomAction (pass false if function is being used to undo/redo zoom, true otherwise)
+     * @param storeZoomAction  (pass false if function is being used to undo/redo zoom, true otherwise)
      * @return
      */
     public boolean unsafeActuallySetZoomAndLocation(String chrXName, String chrYName,

--- a/src/juicebox/data/ChromosomeHandler.java
+++ b/src/juicebox/data/ChromosomeHandler.java
@@ -52,10 +52,16 @@ public class ChromosomeHandler {
     public static int CUSTOM_CHROMOSOME_BUFFER = 5000;
 
     public ChromosomeHandler(List<Chromosome> chromosomes) {
+        this(chromosomes, true);
+    }
+
+    public ChromosomeHandler(List<Chromosome> chromosomes, boolean createAllChr) {
 
         // set the global chromosome list
-        long genomeLength = getTotalLengthOfAllChromosomes(chromosomes);
-        chromosomes.set(0, new Chromosome(0, Globals.CHR_ALL, (int) (genomeLength / 1000)));
+        if (createAllChr) {
+            long genomeLength = getTotalLengthOfAllChromosomes(chromosomes);
+            chromosomes.set(0, new Chromosome(0, Globals.CHR_ALL, (int) (genomeLength / 1000)));
+        }
 
         initializeCleanedChromosomesList(chromosomes);
         initializeInternalVariables();
@@ -314,13 +320,13 @@ public class ChromosomeHandler {
     }
 
     public String getGenomeId() {
-        List<String> chrom_sizes = Arrays.asList("hg19", "hg38", "b37", "hg18", "mm10", "mm9", "GRCm38","aedAeg1", "anasPlat1", "assembly", "bTaurus3", "calJac3", "canFam3", "capHir1", "dm3", "dMel", "EBV", "equCab2", "felCat8", "galGal4", "hg18",  "loxAfr3", "macMul1", "macMulBaylor", "oryCun2", "oryLat2", "panTro4", "Pf3D7", "ratNor5", "ratNor6", "sacCer3", "sCerS288c", "spretus", "susScr3", "TAIR10");
+        List<String> chrom_sizes = Arrays.asList("hg19", "hg38", "b37", "hg18", "mm10", "mm9", "GRCm38", "aedAeg1", "anasPlat1", "assembly", "bTaurus3", "calJac3", "canFam3", "capHir1", "dm3", "dMel", "EBV", "equCab2", "felCat8", "galGal4", "hg18", "loxAfr3", "macMul1", "macMulBaylor", "oryCun2", "oryLat2", "panTro4", "Pf3D7", "ratNor5", "ratNor6", "sacCer3", "sCerS288c", "spretus", "susScr3", "TAIR10");
 
 
-        for (String id:chrom_sizes)  {
+        for (String id : chrom_sizes) {
             ChromosomeHandler handler = HiCFileTools.loadChromosomes(id);
-            for (Chromosome chr:handler.cleanedChromosomes) {
-                for (Chromosome chr2:this.cleanedChromosomes) {
+            for (Chromosome chr : handler.cleanedChromosomes) {
+                for (Chromosome chr2 : this.cleanedChromosomes) {
                     if (!chr.getName().equalsIgnoreCase("ALL") &&
                             chr.getName().equals(chr2.getName()) &&
                             chr.getLength() == chr2.getLength()) {

--- a/src/juicebox/data/DatasetReaderV2.java
+++ b/src/juicebox/data/DatasetReaderV2.java
@@ -135,8 +135,9 @@ public class DatasetReaderV2 extends AbstractDatasetReader {
                 position += 4;
 
                 chromosomes.add(new Chromosome(i, ChromosomeHandler.cleanUpName(name), size));
-            } // todo is the genomewide chr included already?
-            dataset.setChromosomeHandler(new ChromosomeHandler(chromosomes, false));
+            }
+            boolean createWholeChr = false;
+            dataset.setChromosomeHandler(new ChromosomeHandler(chromosomes, createWholeChr));
             // guess genomeID from chromosomes
             String genomeId1 = dataset.getChromosomeHandler().getGenomeId();
             // if cannot find matching genomeID, set based on file

--- a/src/juicebox/data/DatasetReaderV2.java
+++ b/src/juicebox/data/DatasetReaderV2.java
@@ -136,7 +136,7 @@ public class DatasetReaderV2 extends AbstractDatasetReader {
 
                 chromosomes.add(new Chromosome(i, ChromosomeHandler.cleanUpName(name), size));
             } // todo is the genomewide chr included already?
-            dataset.setChromosomeHandler(new ChromosomeHandler(chromosomes));
+            dataset.setChromosomeHandler(new ChromosomeHandler(chromosomes, false));
             // guess genomeID from chromosomes
             String genomeId1 = dataset.getChromosomeHandler().getGenomeId();
             // if cannot find matching genomeID, set based on file

--- a/src/juicebox/data/Matrix.java
+++ b/src/juicebox/data/Matrix.java
@@ -267,6 +267,14 @@ public class Matrix {
 
     }
 
+    public MatrixZoomData getFirstZoomData() {
+        if (bpZoomData != null && bpZoomData.size() > 0) {
+            return getFirstZoomData(HiC.Unit.BP);
+       } else {
+            return getFirstZoomData(HiC.Unit.FRAG);
+        }
+    }
+
     public MatrixZoomData getFirstZoomData(HiC.Unit unit) {
         if (unit == HiC.Unit.BP) {
             return bpZoomData != null && bpZoomData.size() > 0 ? bpZoomData.get(0) : null;

--- a/src/juicebox/gui/MainViewPanel.java
+++ b/src/juicebox/gui/MainViewPanel.java
@@ -458,7 +458,7 @@ public class MainViewPanel {
         annotationsPanel.add(annotationsPanelToggleButton, BorderLayout.SOUTH);
         annotationsPanelToggleButton.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-      rightSidePanel.add(annotationsPanel, BorderLayout.SOUTH);
+        rightSidePanel.add(annotationsPanel, BorderLayout.SOUTH);
         annotationsPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         mainPanel.add(bigPanel, BorderLayout.CENTER);
@@ -541,7 +541,10 @@ public class MainViewPanel {
 
     public void unsafeRefreshChromosomes(SuperAdapter superAdapter) {
 
-        if (chrBox1.getSelectedIndex() == 0 || chrBox2.getSelectedIndex() == 0) {
+        Chromosome chr1 = (Chromosome) chrBox1.getSelectedItem();
+        Chromosome chr2 = (Chromosome) chrBox2.getSelectedItem();
+
+        if (ChromosomeHandler.isAllByAll(chr1) || ChromosomeHandler.isAllByAll(chr2)) {
             chrBox1.setSelectedIndex(0);
             chrBox2.setSelectedIndex(0);
             MatrixType matrixType = (MatrixType) displayOptionComboBox.getSelectedItem();
@@ -552,8 +555,8 @@ public class MainViewPanel {
             }
         }
 
-        Chromosome chr1 = (Chromosome) chrBox1.getSelectedItem();
-        Chromosome chr2 = (Chromosome) chrBox2.getSelectedItem();
+        chr1 = (Chromosome) chrBox1.getSelectedItem();
+        chr2 = (Chromosome) chrBox2.getSelectedItem();
 
         Chromosome chrX = chr1.getIndex() < chr2.getIndex() ? chr1 : chr2;
         Chromosome chrY = chr1.getIndex() < chr2.getIndex() ? chr2 : chr1;
@@ -877,8 +880,8 @@ public class MainViewPanel {
         return displayOptionComboBox;
     }
 
-    public void resetResolutionSlider() {
-        resolutionSlider.unit = HiC.Unit.BP;
+    public void resetResolutionSlider(HiC.Unit unit) {
+        resolutionSlider.unit = unit != null ? unit : HiC.Unit.BP;
         resolutionSlider.reset();
     }
 

--- a/src/juicebox/gui/MainViewPanel.java
+++ b/src/juicebox/gui/MainViewPanel.java
@@ -167,7 +167,7 @@ public class MainViewPanel {
         chrButtonPanel.setLayout(new BoxLayout(chrButtonPanel, BoxLayout.X_AXIS));
 
         //---- chrBox1 ----
-        chrBox1 = new JComboBox<>(new Chromosome[]{new Chromosome(0, Globals.CHR_ALL, 0)});
+        chrBox1 = new JComboBox<>(); //new Chromosome[]{new Chromosome(0, Globals.CHR_ALL, 0)});
         chrBox1.addPopupMenuListener(new BoundsPopupMenuListener<Chromosome>(true, false));
         chrBox1.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
@@ -178,7 +178,7 @@ public class MainViewPanel {
         chrButtonPanel.add(chrBox1);
 
         //---- chrBox2 ----
-        chrBox2 = new JComboBox<>(new Chromosome[]{new Chromosome(0, Globals.CHR_ALL, 0)});
+        chrBox2 = new JComboBox<>(); //new Chromosome[]{new Chromosome(0, Globals.CHR_ALL, 0)});
         chrBox2.addPopupMenuListener(new BoundsPopupMenuListener<Chromosome>(true, false));
         chrBox2.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
This PR does several things
* Removes built-in assumptions that "chr ALL" exists in the .hic file.  This made it impossible to load a .hic file that did not have a "chr ALL" in the zero position of the chromosome list.
* Fix bug preventing loading .hic files with no BP resolutions (i.e. only FRAG resolutions)
* Clear some state improperly retained from map to map.  Specifically
    * controlDataset
    * displayOption
    * currentZoom
    * binSizeDictionary
