### PR TITLE
Add math3 to juicer_tools artifact

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -336,6 +336,7 @@
                         prefix="META-INF"/>
             <zipfileset dir="${juicebox.output.dir}"/>
             <zipfileset src="${basedir}/lib/general/jsi1.1.jar" excludes="META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA"/>
+            <zipfileset src="${basedir}/lib/general/commons-math3-3.6.1.jar"/>
             <zipfileset src="${basedir}/lib/general/guava-18.0.jar"/>
             <zipfileset src="${basedir}/lib/general/VectorGraphics2D-0.11.jar"/>
             <zipfileset src="${basedir}/lib/broadinstitute/igv.jar"


### PR DESCRIPTION
When running without this fix we would get a class not found via org apache math3 from juicer_tools.jar in the hic/hic30 steps of juicer. Could be our environment, but without this change that step failed every time from a freshly cloned/built repo.